### PR TITLE
Refactor login, add trigger scripts and migrations

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -22,7 +22,6 @@ const Login = () => {
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
   const [confirm, setConfirm] = useState("");
-  const [userType, setUserType] = useState("MEMBER");
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -48,7 +47,7 @@ const Login = () => {
           first_name: firstName,
           last_name: lastName,
           email,
-          user_type: userType,
+          user_type: "MEMBER",
         });
         setNotice("Account created. Signing you in...");
         // Auto-login after successful registration
@@ -240,19 +239,6 @@ const Login = () => {
                       className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                       placeholder="••••••••"
                     />
-                  </div>
-                  <div>
-                    <label className="block text-sm text-gray-700">
-                      Account type
-                    </label>
-                    <select
-                      value={userType}
-                      onChange={(e) => setUserType(e.target.value)}
-                      className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    >
-                      <option value="MEMBER">Member</option>
-                      <option value="ADMIN">Admin</option>
-                    </select>
                   </div>
                   <label className="inline-flex items-start gap-2 text-xs text-gray-600">
                     <input

--- a/server/checkTriggers.js
+++ b/server/checkTriggers.js
@@ -1,0 +1,24 @@
+const { getConnection } = require('./db');
+
+async function checkTriggers() {
+  try {
+    const conn = await getConnection();
+    const result = await conn.execute(`
+      SELECT trigger_name, status, table_name
+      FROM user_triggers 
+      WHERE table_name IN ('BOOKS', 'BOOK_STOCK', 'LOANS')
+      ORDER BY table_name, trigger_name
+    `);
+    
+    console.log('Triggers on BOOKS, BOOK_STOCK, and LOANS tables:');
+    result.rows.forEach(row => {
+      console.log(`${row[2]}.${row[0]}: ${row[1]}`);
+    });
+    
+    await conn.close();
+  } catch (err) {
+    console.error('Error:', err.message);
+  }
+}
+
+checkTriggers();

--- a/server/disableTrigger.js
+++ b/server/disableTrigger.js
@@ -1,0 +1,18 @@
+const { getConnection } = require('./db');
+
+async function disableTrigger() {
+  try {
+    const conn = await getConnection();
+    
+    console.log('Disabling TRG_AUTO_FULFILL_RESERVATION trigger...');
+    await conn.execute('ALTER TRIGGER TRG_AUTO_FULFILL_RESERVATION DISABLE');
+    
+    console.log('Trigger disabled successfully!');
+    
+    await conn.close();
+  } catch (err) {
+    console.error('Error:', err.message);
+  }
+}
+
+disableTrigger();

--- a/server/migrations/015_delete_fully_available_books.sql
+++ b/server/migrations/015_delete_fully_available_books.sql
@@ -1,0 +1,28 @@
+-- 015_delete_fully_available_books.sql
+-- Deletes all books that are fully available (all copies free and none reserved)
+-- along with dependent rows to satisfy FK constraints.
+-- Criteria: available_copies = total_copies AND reserved_copies = 0
+
+-- Collect target books
+CREATE TABLE TMP_BOOKS_TO_DELETE AS
+SELECT book_id
+  FROM books
+ WHERE available_copies = total_copies
+   AND reserved_copies = 0;
+
+-- Remove dependent rows first (FKs without cascade)
+DELETE FROM notifications
+ WHERE book_id IN (SELECT book_id FROM TMP_BOOKS_TO_DELETE);
+
+DELETE FROM reservations
+ WHERE book_id IN (SELECT book_id FROM TMP_BOOKS_TO_DELETE);
+
+DELETE FROM loans
+ WHERE book_id IN (SELECT book_id FROM TMP_BOOKS_TO_DELETE);
+
+-- book_authors has ON DELETE CASCADE; deleting books will remove join rows
+DELETE FROM books
+ WHERE book_id IN (SELECT book_id FROM TMP_BOOKS_TO_DELETE);
+
+-- Cleanup
+DROP TABLE TMP_BOOKS_TO_DELETE PURGE;

--- a/server/migrations/016_fix_delete_deadlock_trigger.sql
+++ b/server/migrations/016_fix_delete_deadlock_trigger.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE TRIGGER trg_update_stock_on_return
+AFTER UPDATE OF return_date ON loans
+FOR EACH ROW
+WHEN (new.return_date IS NOT NULL AND old.return_date IS NULL)
+DECLARE
+  v_book_id books.book_id%TYPE;
+BEGIN
+  -- Get the book_id from the book_stock table using the stock_id
+  SELECT book_id INTO v_book_id
+  FROM book_stock
+  WHERE stock_id = :new.stock_id;
+
+  -- Call the procedure to update the stock
+  pkg_stock.update_stock_on_return(v_book_id);
+END;
+/

--- a/server/migrations/017_disable_cascade_trigger.sql
+++ b/server/migrations/017_disable_cascade_trigger.sql
@@ -1,0 +1,2 @@
+ALTER TRIGGER trg_delete_book_cascade DISABLE;
+/

--- a/server/migrations/017_disable_deadlock_trigger.sql
+++ b/server/migrations/017_disable_deadlock_trigger.sql
@@ -1,0 +1,2 @@
+ALTER TRIGGER trg_delete_book_cascade DISABLE;
+/

--- a/server/migrations/017_disable_delete_cascade_trigger.sql
+++ b/server/migrations/017_disable_delete_cascade_trigger.sql
@@ -1,0 +1,2 @@
+ALTER TRIGGER trg_delete_book_cascade DISABLE;
+/


### PR DESCRIPTION
Simplified the Login page by removing the user type selection and defaulting registration to MEMBER. Added server scripts to check and disable triggers, and introduced SQL migrations for deleting fully available books, fixing deadlock triggers, and disabling cascade triggers.